### PR TITLE
Add process parallelism and use the standard logging module.

### DIFF
--- a/ncistd/__init__.py
+++ b/ncistd/__init__.py
@@ -1,6 +1,10 @@
+import logging
+
 from .decomposition import (
     als_lasso, 
     SparseCP
 )
 from .tensors import simulated_sparse_tensor
 from .utils import *
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/ncistd/tests/test_decomposition.py
+++ b/ncistd/tests/test_decomposition.py
@@ -95,7 +95,6 @@ def test_als_lasso(
         n_iter_max=n_iter_max,  
         random_state=rns, 
         threads=None, 
-        verbose=0, 
         return_losses=True
     )
     
@@ -180,7 +179,6 @@ def test_als_lasso_random_seed(
         n_iter_max=n_iter_max,  
         random_state=seed, 
         threads=None, 
-        verbose=0, 
         return_losses=True
     )
     # check that same random seeding yeilds same results
@@ -198,7 +196,6 @@ def test_als_lasso_random_seed(
         n_iter_max=n_iter_max,  
         random_state=seed, 
         threads=None, 
-        verbose=0, 
         return_losses=True
     )
     assert_array_equal(loss, second_loss)
@@ -235,7 +232,6 @@ def test_als_lasso_solutions(
         n_iter_max=n_iter_max,  
         random_state=seed, 
         threads=None, 
-        verbose=0, 
         return_losses=True
     )
     # target solution metrics


### PR DESCRIPTION
An example of configuring logging in application code to use an object named `logger`.

```
logger = logging.getLogger()
logger.setLevel(logging.INFO)
logging_ch = logging.StreamHandler()
logging_ch.setFormatter(
    logging.Formatter(fmt="%(asctime)s pid=%(process)-10s %(levelname)s %(module)s %(funcName)s %(message)s")
)
logger.addHandler(logging_ch)
logging.getLogger("ncistd").setLevel(logging.INFO)  # set ncistd logging level here
```

I attempted to use thread parallelism for multiple initializations, since numpy will release the GIL, but this deadlocked with more than 2 threads, which shouldn't happen. Process parallelism doesn't have this problem, but there is some extra work required to clean up child processes if the parent process is killed with SIGTERM. Use a signal handler in combination with a multiprocessing Manager Event to cleanly shut down the initialization process pool in this scenario.

```
exit_code = 0

def signal_handler(shutdown_event:):
    if not isinstance(shutdown_event, mp.managers.EventProxy):
        raise TypeError("shutdown_event of must be a mp.managers.EventProxy")

    def f(signum, frame):
        # Store which signal was received to create the proper exit code
        # https://tldp.org/LDP/abs/html/exitcodes.html
        global exit_code
        exit_code = 128 + signum

        logger.info("got %d, setting shutdown event", signum)
        shutdown_event.set()
        logger.info("exiting signal handler")

    return f

def run():
    with mp.Manager() as manager:
        shutdown_event = manager.Event()
        signal.signal(signal.SIGTERM, signal_handler(shutdown_event))
        signal.signal(signal.SIGINT, signal_handler(shutdown_event))
        
        # set up fit_transform data and parameters
        # ...
        best_cp = model.fit_transform(
            sim_cp.to_tensor(),
            threads=threads_per_process,
            return_losses=False,
            initialization_processes=initialization_processes,
            shutdown_event=shutdown_event,
        )
        if best_cp is None:
            logger.warning("exiting")
            sys.exit(exit_code)

        # keep doing things with best_cp
```